### PR TITLE
feat: Add an HTTP test file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+bin
+obj
+csx
+.vs
+edge
+Publish
+
+*.user
+*.suo
+*.cscfg
+*.Cache
+project.lock.json
+
+/packages
+/TestResults
+
+/tools/NuGet.exe
+/App_Data
+/secrets
+/data
+.secrets
+appsettings.json
+local.settings.json
+
+node_modules
+dist
+
+# Local python packages
+.python_packages/
+
+# Python Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,20 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
 name: azure-ipaas-workshop
+
+hooks:
+  postprovision:
+    windows:
+      shell: pwsh
+      run: ./infra/scripts/postprovision.ps1
+      interactive: true
+      continueOnError: false
+    posix:
+      shell: sh
+      run: ./infra/scripts/postprovision.sh
+      interactive: true
+      continueOnError: false
+
 services:
   dataprocessing:
     project: ./src/dataprocessing

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -473,3 +473,7 @@ module keyVaultUserAssignment './keyvault-role-assign.bicep' = {
     principalType: principalType
   }
 }
+
+output AZURE_APIM_NAME string = apim.outputs.name
+output AZURE_DATA_FETCHING_FUNC_APP_NAME string = dataFetchingFunctionApp.outputs.name
+output AZURE_TENANT_ID string = tenant().tenantId

--- a/infra/scripts/postprovision.ps1
+++ b/infra/scripts/postprovision.ps1
@@ -1,0 +1,2 @@
+# Load azd environment variables to .env file for testing deployed functions and apim
+azd env get-values > .env

--- a/infra/scripts/postprovision.sh
+++ b/infra/scripts/postprovision.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# Load azd environment variables to .env file for testing deployed functions and apim
+azd env get-values > .env

--- a/tests.http
+++ b/tests.http
@@ -1,0 +1,33 @@
+# FetchOrders
+
+## By calling the Function App directly
+
+GET https://{{$dotenv AZURE_DATA_FETCHING_FUNC_APP_NAME}}.azurewebsites.net/api/FetchOrders HTTP/1.1
+
+###
+
+## By calling APIM without subscription key
+
+
+GET https://{{$dotenv AZURE_APIM_NAME}}.azure-api.net/orders/FetchOrders HTTP/1.1
+
+###
+
+## By calling APIM using a subscription key
+
+
+GET https://{{$dotenv AZURE_APIM_NAME}}.azure-api.net/orders/FetchOrders HTTP/1.1
+Ocp-Apim-Subscription-Key: REPLACE_WITH_MY_SUBSCRIPTION_KEY
+
+
+###
+
+# Getting the Access Token
+
+POST https://login.microsoftonline.com/{{$dotenv AZURE_TENANT_ID}}/oauth2/v2.0/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=
+&client_secret=
+&scope=


### PR DESCRIPTION
Add an HTTP test file compatible with REST Client to test fetching orders. The file relies on environment variables generated by azd when provisioning resources on Azure.

<img width="421" alt="image" src="https://github.com/user-attachments/assets/3c5509cb-092c-49e2-a5d6-4140d67278a9" />


noissue